### PR TITLE
ci: release caliobase from GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,12 +91,16 @@ jobs:
           echo "All services are ready!"
 
       - name: Release
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_PREID: ${{ inputs.preid }}
+          RELEASE_DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          args=("${{ inputs.version }}")
-          if [[ -n "${{ inputs.preid }}" ]]; then
-            args+=("--preid" "${{ inputs.preid }}")
+          args=("$RELEASE_VERSION")
+          if [[ -n "$RELEASE_PREID" ]]; then
+            args+=("--preid" "$RELEASE_PREID")
           fi
-          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+          if [[ "$RELEASE_DRY_RUN" == "true" ]]; then
             args+=("--dry-run")
           fi
           npm run release -- "${args[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version bump/specifier to release'
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prerelease
+      preid:
+        description: 'Optional prerelease identifier, e.g. beta'
+        required: false
+        type: string
+      dry_run:
+        description: 'Run the release flow without publishing or pushing tags'
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: caliobase-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release npm packages
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      - name: Require main branch
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Releases must be run from main. Current ref: $GITHUB_REF" >&2
+          exit 1
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Docker Compose
+        uses: docker/setup-compose-action@v1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Require npm token
+        if: ${{ !inputs.dry_run }}
+        run: |
+          if [[ -z "${NPM_TOKEN}" ]]; then
+            echo "NPM_TOKEN secret is required for publishing." >&2
+            exit 1
+          fi
+
+      - name: Configure npm authentication
+        if: ${{ !inputs.dry_run }}
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Start test infrastructure
+        run: |
+          cd packages/test-infra
+          docker compose up -d
+
+      - name: Wait for services to be ready
+        run: |
+          cd packages/test-infra
+          echo "Waiting for services to be healthy..."
+          timeout 60 bash -c 'until docker compose exec -T postgres pg_isready -U test -d test -h localhost; do echo "Waiting for PostgreSQL..."; sleep 5; done'
+          timeout 60 bash -c 'until docker compose exec -T mysql mysqladmin ping -h localhost --silent; do echo "Waiting for MySQL..."; sleep 5; done'
+          timeout 60 bash -c 'until docker compose exec -T redis redis-cli ping; do echo "Waiting for Redis..."; sleep 5; done'
+          timeout 120 bash -c 'until docker compose exec -T localstack awslocal sqs list-queues > /dev/null 2>&1; do echo "Waiting for LocalStack..."; sleep 5; done'
+          timeout 120 bash -c 'until docker compose exec -T minio mc ready local > /dev/null 2>&1; do echo "Waiting for MinIO..."; sleep 5; done'
+          echo "All services are ready!"
+
+      - name: Release
+        run: |
+          args=("${{ inputs.version }}")
+          if [[ -n "${{ inputs.preid }}" ]]; then
+            args+=("--preid" "${{ inputs.preid }}")
+          fi
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            args+=("--dry-run")
+          fi
+          npm run release -- "${args[@]}"
+
+      - name: Cleanup test infrastructure
+        if: always()
+        run: |
+          cd packages/test-infra
+          docker compose down -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -36,8 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_CONFIG_PROVENANCE: true
 
     steps:
       - name: Require main branch
@@ -61,22 +61,15 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Use npm with trusted publishing support
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
+
       - name: Configure git author
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Require npm token
-        if: ${{ !inputs.dry_run }}
-        run: |
-          if [[ -z "${NPM_TOKEN}" ]]; then
-            echo "NPM_TOKEN secret is required for publishing." >&2
-            exit 1
-          fi
-
-      - name: Configure npm authentication
-        if: ${{ !inputs.dry_run }}
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
       - name: Install dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -98,6 +98,6 @@ Caliobase packages are released from GitHub Actions instead of a developer machi
 3. Choose the version bump (`patch`, `minor`, `major`, or `prerelease`).
 4. Leave `dry_run` enabled for a smoke test, or disable it to publish.
 
-The release workflow runs tests/builds, uses Nx Release to update package versions and changelogs, publishes packages to npm, and pushes the release commit/tags back to GitHub. The repository must have an `NPM_TOKEN` secret containing an npm automation token with publish access.
+The release workflow runs tests/builds, uses Nx Release to update package versions and changelogs, publishes packages to npm, and pushes the release commit/tags back to GitHub. npm publishing uses trusted publishing via GitHub Actions OIDC, so each published package must trust this repository/workflow in npm and no `NPM_TOKEN` secret is required.
 
 Local fallback remains available with `npm run release -- patch`; local publishes prompt for an npm OTP unless `NPM_OTP` is set.

--- a/README.md
+++ b/README.md
@@ -88,3 +88,16 @@ Nx Cloud pairs with Nx in order to enable you to build and test code more rapidl
 Teams using Nx gain the advantage of building full-stack applications with their preferred framework alongside Nx’s advanced code generation and project dependency graph, plus a unified experience for both frontend and backend developers.
 
 Visit [Nx Cloud](https://nx.app/) to learn more.
+
+## Releases
+
+Caliobase packages are released from GitHub Actions instead of a developer machine.
+
+1. Open **Actions → Release** in GitHub.
+2. Run the workflow from `main`.
+3. Choose the version bump (`patch`, `minor`, `major`, or `prerelease`).
+4. Leave `dry_run` enabled for a smoke test, or disable it to publish.
+
+The release workflow runs tests/builds, uses Nx Release to update package versions and changelogs, publishes packages to npm, and pushes the release commit/tags back to GitHub. The repository must have an `NPM_TOKEN` secret containing an npm automation token with publish access.
+
+Local fallback remains available with `npm run release -- patch`; local publishes prompt for an npm OTP unless `NPM_OTP` is set.

--- a/tools/scripts/release.sh
+++ b/tools/scripts/release.sh
@@ -19,7 +19,7 @@ Runs the caliobase Nx release flow:
   7. push commits/tags
 
 Local releases prompt for npm OTP unless NPM_OTP is set.
-CI releases require NPM_TOKEN and use npm automation tokens instead of OTP.
+CI releases use npm trusted publishing via GitHub Actions OIDC.
 USAGE
 }
 
@@ -90,12 +90,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
   exit 0
 fi
 
-if [[ "${CI:-}" == "true" ]]; then
-  if [[ -z "${NPM_TOKEN:-}" ]]; then
-    echo "Error: NPM_TOKEN is required for CI releases." >&2
-    exit 1
-  fi
-else
+if [[ "${CI:-}" != "true" ]]; then
   if [[ -z "${NPM_OTP:-}" ]]; then
     echo ""
     echo "Ready to publish to npm."

--- a/tools/scripts/release.sh
+++ b/tools/scripts/release.sh
@@ -1,29 +1,119 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_SPECIFIER="patch"
+PREID=""
+DRY_RUN="false"
+
+usage() {
+  cat <<'USAGE'
+Usage: npm run release -- [patch|minor|major|prerelease|<version>] [--preid <id>] [--dry-run]
+
+Runs the caliobase Nx release flow:
+  1. fetch tags
+  2. test
+  3. build
+  4. version/changelog/tag packages
+  5. rebuild
+  6. publish to npm
+  7. push commits/tags
+
+Local releases prompt for npm OTP unless NPM_OTP is set.
+CI releases require NPM_TOKEN and use npm automation tokens instead of OTP.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --preid)
+      PREID="${2:-}"
+      if [[ -z "$PREID" ]]; then
+        echo "Error: --preid requires a value" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --preid=*)
+      PREID="${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    patch|minor|major|prerelease|prepatch|preminor|premajor)
+      RELEASE_SPECIFIER="$1"
+      shift
+      ;;
+    *)
+      if [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+        RELEASE_SPECIFIER="$1"
+        shift
+      else
+        echo "Error: unknown release argument '$1'" >&2
+        usage >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+NX_VERSION_ARGS=("$RELEASE_SPECIFIER")
+NX_PUBLISH_ARGS=()
+
+if [[ -n "$PREID" ]]; then
+  NX_VERSION_ARGS+=("--preid" "$PREID")
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  NX_VERSION_ARGS+=("--dry-run")
+  NX_PUBLISH_ARGS+=("--dry-run")
+fi
 
 # Fetch tags and run tests/build
 git fetch --all --tags
 npm run test
 npm run build
 
-# Version bump
-nx release version patch
+# Version bump / changelog / tags
+npx nx release version "${NX_VERSION_ARGS[@]}"
 
 # Rebuild with new versions
 npm run build
 
-# Prompt for OTP
-echo ""
-echo "Ready to publish to npm."
-read -p "Enter your npm OTP code: " OTP
-
-if [ -z "$OTP" ]; then
-  echo "Error: OTP is required"
-  exit 1
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Dry run complete; skipping npm publish and git push."
+  exit 0
 fi
 
-# Publish with OTP
-nx release publish patch --otp="$OTP"
+if [[ "${CI:-}" == "true" ]]; then
+  if [[ -z "${NPM_TOKEN:-}" ]]; then
+    echo "Error: NPM_TOKEN is required for CI releases." >&2
+    exit 1
+  fi
+else
+  if [[ -z "${NPM_OTP:-}" ]]; then
+    echo ""
+    echo "Ready to publish to npm."
+    read -r -p "Enter your npm OTP code: " NPM_OTP
+  fi
 
-# Push tags
+  if [[ -z "${NPM_OTP:-}" ]]; then
+    echo "Error: OTP is required for local releases." >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "${NPM_OTP:-}" ]]; then
+  NX_PUBLISH_ARGS+=("--otp=$NPM_OTP")
+fi
+
+# Publish to npm
+npx nx release publish "${NX_PUBLISH_ARGS[@]}"
+
+# Push release commits/tags
 git push --follow-tags

--- a/tools/scripts/release.sh
+++ b/tools/scripts/release.sh
@@ -7,7 +7,7 @@ DRY_RUN="false"
 
 usage() {
   cat <<'USAGE'
-Usage: npm run release -- [patch|minor|major|prerelease|<version>] [--preid <id>] [--dry-run]
+Usage: npm run release -- [patch|minor|major|prerelease|prepatch|preminor|premajor|<version>] [--preid <id>|--preid=<id>] [--dry-run]
 
 Runs the caliobase Nx release flow:
   1. fetch tags
@@ -18,7 +18,7 @@ Runs the caliobase Nx release flow:
   6. publish to npm
   7. push commits/tags
 
-Local releases prompt for npm OTP unless NPM_OTP is set.
+Local releases prompt for npm OTP unless NPM_OTP or NPM_TOKEN is set.
 CI releases use npm trusted publishing via GitHub Actions OIDC.
 USAGE
 }
@@ -90,7 +90,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
   exit 0
 fi
 
-if [[ "${CI:-}" != "true" ]]; then
+if [[ "${CI:-}" != "true" && -z "${NPM_TOKEN:-}" ]]; then
   if [[ -z "${NPM_OTP:-}" ]]; then
     echo ""
     echo "Ready to publish to npm."
@@ -98,7 +98,7 @@ if [[ "${CI:-}" != "true" ]]; then
   fi
 
   if [[ -z "${NPM_OTP:-}" ]]; then
-    echo "Error: OTP is required for local releases." >&2
+    echo "Error: OTP is required for local releases unless NPM_TOKEN is set." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary
- Add a manual GitHub Actions `Release` workflow for npm package releases.
- Make `tools/scripts/release.sh` CI-aware: supports release specifiers, prerelease IDs, dry runs, GitHub Actions trusted publishing, local npm automation tokens, and local OTP fallback.
- Document the GitHub Actions release process and npm trusted publishing setup.

## Notes
- This is stacked on #6 (`octavius/caliobase-ci-cleanup`) because current `main` CI/build stability work needs to land first.
- The release workflow defaults to `dry_run: true`; publishing requires disabling dry run and configuring npm trusted publishing for this repository/workflow. No `NPM_TOKEN` repository secret is required for the CI path.

## Validation
- `bash -n tools/scripts/release.sh`
- Parsed `.github/workflows/release.yml` with PyYAML
- `ASDF_NODEJS_VERSION=20.20.2 npm run release -- --help`
- Prior validation on this PR: `npm ci` with Node 20.20.2, `npm run build`, and `npx nx release version patch --dry-run`

## Known existing blockers
- `npm run lint` currently fails in `caliobase-nx` with an existing `@nx/dependency-checks` error on `@caliobase/caliobase`.
- Full `npm run release -- patch --dry-run` could not be run locally because another project has LocalStack bound to port 4566; the workflow itself starts the expected test infrastructure in a clean runner.
