### PR TITLE
fix: avoid auth role decorator circular import

### DIFF
--- a/packages/caliobase/src/auth/decorators/role.decorator.ts
+++ b/packages/caliobase/src/auth/decorators/role.decorator.ts
@@ -1,6 +1,6 @@
 import { ExecutionContext, SetMetadata } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { Role, Roles } from '../../entity-module';
+import { Role, Roles } from '../../entity-module/roles';
 
 export const ALLOWED_ROLES = Symbol('allowed_roles');
 


### PR DESCRIPTION
## Summary
- Fixes the runtime/module-load break from PR #9 by avoiding the `entity-module` barrel import inside the auth role decorator.
- The barrel path created a circular import after `MachineAuthController` started using `@RequireRoleOrHigher`, leaving `Roles` undefined during import.

## Validation
- `ASDF_NODEJS_VERSION=20.20.2 npx nx test caliobase --output-style=stream` ✅ 74 passed
- `ASDF_NODEJS_VERSION=20.20.2 npx nx lint caliobase --output-style=stream` ✅ 0 errors, 16 existing warnings
- `ASDF_NODEJS_VERSION=20.20.2 npx nx run-many --target=build --projects=typeorm-migrations,caliobase --parallel=1 --output-style=stream` ✅

Note: local `docker compose up -d` for test infra hit a port conflict on LocalStack `4566`, but Postgres/MySQL/Redis/MinIO were healthy and sufficient for `caliobase:test`.
