### PR TITLE
fix: add package repository metadata for provenance

### DIFF
--- a/packages/caliobase-cdk/package.json
+++ b/packages/caliobase-cdk/package.json
@@ -6,5 +6,10 @@
     "@ji-constructs/ecs-jwt-keypair": "^0.1.7",
     "aws-cdk-lib": "^2.38.1",
     "constructs": "^10.1.85"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/justicointeractive/caliobase",
+    "directory": "packages/caliobase-cdk"
   }
 }

--- a/packages/caliobase-nx/package.json
+++ b/packages/caliobase-nx/package.json
@@ -20,5 +20,10 @@
     "semver": "7.3.4",
     "swagger-typescript-api-nextgen": "^10.0.1",
     "tslib": "^2.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/justicointeractive/caliobase",
+    "directory": "packages/caliobase-nx"
   }
 }

--- a/packages/caliobase-ui/package.json
+++ b/packages/caliobase-ui/package.json
@@ -25,5 +25,10 @@
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "react-modal-promise": "^1.0.2",
     "indefinite": "^2.4.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/justicointeractive/caliobase",
+    "directory": "packages/caliobase-ui"
   }
 }

--- a/packages/caliobase/package.json
+++ b/packages/caliobase/package.json
@@ -33,5 +33,10 @@
     "pluralize": "^8.0.0",
     "react": "^18.2.0",
     "typeorm": "^0.3.20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/justicointeractive/caliobase",
+    "directory": "packages/caliobase"
   }
 }

--- a/packages/typeorm-migrations/package.json
+++ b/packages/typeorm-migrations/package.json
@@ -7,5 +7,10 @@
     "lodash": "^4.17.21",
     "typeorm": "^0.3.20",
     "yaml": "^2.1.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/justicointeractive/caliobase",
+    "directory": "packages/typeorm-migrations"
   }
 }

--- a/packages/use-async-effect-state/package.json
+++ b/packages/use-async-effect-state/package.json
@@ -4,5 +4,10 @@
   "dependencies": {
     "react": "^18.2.0",
     "rxjs": "^7.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/justicointeractive/caliobase",
+    "directory": "packages/use-async-effect-state"
   }
 }


### PR DESCRIPTION
## Summary
- add repository metadata to all publishable package manifests
- include package directories while keeping repository.url matched to the provenance source repo
- unblocks npm trusted publishing provenance validation for the next Caliobase patch release

## Validation
- `node -e` check that every publishable package has repository.url `https://github.com/justicointeractive/caliobase`
- `git diff --check`
- `npm pack --dry-run --json` for all publishable packages

## Notes
- Joe confirmed `use-async-effect-state` npm setup was updated separately; this PR addresses the remaining package metadata/provenance failure.
