### PR TITLE
chore: sync published Caliobase release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36592,11 +36592,11 @@
     },
     "packages/caliobase": {
       "name": "@caliobase/caliobase",
-      "version": "0.7.20",
+      "version": "0.7.21",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.282.0",
         "@aws-sdk/s3-request-presigner": "^3.282.0",
-        "@caliobase/typeorm-migrations": "0.0.52",
+        "@caliobase/typeorm-migrations": "0.0.53",
         "@faire/mjml-react": "^3.3.0",
         "@nestjs/common": "^10.3.3",
         "@nestjs/config": "^3.2.0",
@@ -36616,10 +36616,10 @@
         "commander": "^9.4.0",
         "crypto-random-string": "^3.3.1",
         "date-fns": "^2.28.0",
-        "jose": "^4.8.3",
         "lodash": "^4.17.21",
         "nanoid": "^3.3.4",
         "nodemailer": "^6.7.5",
+        "jose": "^4.8.3",
         "openid-client": "^5.1.8",
         "passport-jwt": "^4.0.0",
         "pluralize": "^8.0.0",
@@ -36629,7 +36629,7 @@
     },
     "packages/caliobase-cdk": {
       "name": "@caliobase/caliobase-cdk",
-      "version": "0.2.47",
+      "version": "0.2.48",
       "dependencies": {
         "@ji-constructs/cdk-image-resize-behavior": "^0.5.9",
         "@ji-constructs/ecs-jwt-keypair": "^0.1.7",
@@ -36639,10 +36639,10 @@
     },
     "packages/caliobase-nx": {
       "name": "@caliobase/caliobase-nx",
-      "version": "0.3.53",
+      "version": "0.3.54",
       "dependencies": {
-        "@caliobase/caliobase": "0.7.20",
-        "@caliobase/caliobase-ui": "0.3.49",
+        "@caliobase/caliobase-ui": "0.3.50",
+        "@caliobase/caliobase": "0.7.21",
         "@nestjs/common": "10.3.3",
         "@nestjs/core": "10.3.3",
         "@nestjs/platform-express": "10.3.3",
@@ -36660,31 +36660,31 @@
     },
     "packages/caliobase-ui": {
       "name": "@caliobase/caliobase-ui",
-      "version": "0.3.49",
+      "version": "0.3.50",
       "dependencies": {
+        "react": "^18.2.0",
+        "@floating-ui/react-dom-interactions": "^0.9.2",
+        "lodash": "^4.17.21",
+        "@fortawesome/free-solid-svg-icons": "^6.1.2",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "clsx": "^1.2.1",
+        "@fortawesome/free-regular-svg-icons": "^6.1.2",
+        "@headlessui-float/react": "^0.9.1",
+        "@headlessui/react": "^1.7.16",
+        "date-fns": "^2.28.0",
         "@editorjs/attaches": "^1.2.2",
         "@editorjs/editorjs": "^2.25.0",
         "@editorjs/header": "^2.6.2",
         "@editorjs/image": "^2.6.2",
         "@editorjs/list": "^1.7.0",
-        "@floating-ui/react-dom-interactions": "^0.9.2",
-        "@fortawesome/fontawesome-svg-core": "^6.2.0",
-        "@fortawesome/free-regular-svg-icons": "^6.1.2",
-        "@fortawesome/free-solid-svg-icons": "^6.1.2",
-        "@fortawesome/react-fontawesome": "^0.2.0",
-        "@headlessui-float/react": "^0.9.1",
-        "@headlessui/react": "^1.7.16",
-        "circumspect": "^0.1.1",
-        "clsx": "^1.2.1",
-        "date-fns": "^2.28.0",
-        "indefinite": "^2.4.1",
-        "lodash": "^4.17.21",
-        "react": "^18.2.0",
-        "react-modal-promise": "^1.0.2",
-        "react-router-dom": "6.11.2",
+        "use-async-effect-state": "0.2.49",
         "rxjs": "^7.0.0",
+        "react-router-dom": "6.11.2",
+        "circumspect": "^0.1.1",
         "tailwind-override": "^0.6.1",
-        "use-async-effect-state": "0.2.48"
+        "@fortawesome/fontawesome-svg-core": "^6.2.0",
+        "react-modal-promise": "^1.0.2",
+        "indefinite": "^2.4.1"
       }
     },
     "packages/packages/caliobase-nx": {
@@ -36697,7 +36697,7 @@
     },
     "packages/typeorm-migrations": {
       "name": "@caliobase/typeorm-migrations",
-      "version": "0.0.52",
+      "version": "0.0.53",
       "dependencies": {
         "@sqltools/formatter": "1.2.5",
         "circumspect": "^0.1.1",
@@ -36707,7 +36707,7 @@
       }
     },
     "packages/use-async-effect-state": {
-      "version": "0.2.48",
+      "version": "0.2.49",
       "dependencies": {
         "react": "^18.2.0",
         "rxjs": "^7.0.0"
@@ -39309,7 +39309,7 @@
       "requires": {
         "@aws-sdk/client-s3": "^3.282.0",
         "@aws-sdk/s3-request-presigner": "^3.282.0",
-        "@caliobase/typeorm-migrations": "0.0.52",
+        "@caliobase/typeorm-migrations": "0.0.53",
         "@faire/mjml-react": "^3.3.0",
         "@nestjs/common": "^10.3.3",
         "@nestjs/config": "^3.2.0",
@@ -39329,10 +39329,10 @@
         "commander": "^9.4.0",
         "crypto-random-string": "^3.3.1",
         "date-fns": "^2.28.0",
-        "jose": "^4.8.3",
         "lodash": "^4.17.21",
         "nanoid": "^3.3.4",
         "nodemailer": "^6.7.5",
+        "jose": "^4.8.3",
         "openid-client": "^5.1.8",
         "passport-jwt": "^4.0.0",
         "pluralize": "^8.0.0",
@@ -39352,8 +39352,8 @@
     "@caliobase/caliobase-nx": {
       "version": "file:packages/caliobase-nx",
       "requires": {
-        "@caliobase/caliobase": "0.7.20",
-        "@caliobase/caliobase-ui": "0.3.49",
+        "@caliobase/caliobase-ui": "0.3.50",
+        "@caliobase/caliobase": "0.7.21",
         "@nestjs/common": "10.3.3",
         "@nestjs/core": "10.3.3",
         "@nestjs/platform-express": "10.3.3",
@@ -39372,29 +39372,29 @@
     "@caliobase/caliobase-ui": {
       "version": "file:packages/caliobase-ui",
       "requires": {
+        "react": "^18.2.0",
+        "@floating-ui/react-dom-interactions": "^0.9.2",
+        "lodash": "^4.17.21",
+        "@fortawesome/free-solid-svg-icons": "^6.1.2",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "clsx": "^1.2.1",
+        "@fortawesome/free-regular-svg-icons": "^6.1.2",
+        "@headlessui-float/react": "^0.9.1",
+        "@headlessui/react": "^1.7.16",
+        "date-fns": "^2.28.0",
         "@editorjs/attaches": "^1.2.2",
         "@editorjs/editorjs": "^2.25.0",
         "@editorjs/header": "^2.6.2",
         "@editorjs/image": "^2.6.2",
         "@editorjs/list": "^1.7.0",
-        "@floating-ui/react-dom-interactions": "^0.9.2",
-        "@fortawesome/fontawesome-svg-core": "^6.2.0",
-        "@fortawesome/free-regular-svg-icons": "^6.1.2",
-        "@fortawesome/free-solid-svg-icons": "^6.1.2",
-        "@fortawesome/react-fontawesome": "^0.2.0",
-        "@headlessui-float/react": "^0.9.1",
-        "@headlessui/react": "^1.7.16",
-        "circumspect": "^0.1.1",
-        "clsx": "^1.2.1",
-        "date-fns": "^2.28.0",
-        "indefinite": "^2.4.1",
-        "lodash": "^4.17.21",
-        "react": "^18.2.0",
-        "react-modal-promise": "^1.0.2",
-        "react-router-dom": "6.11.2",
+        "use-async-effect-state": "0.2.49",
         "rxjs": "^7.0.0",
+        "react-router-dom": "6.11.2",
+        "circumspect": "^0.1.1",
         "tailwind-override": "^0.6.1",
-        "use-async-effect-state": "0.2.48"
+        "@fortawesome/fontawesome-svg-core": "^6.2.0",
+        "react-modal-promise": "^1.0.2",
+        "indefinite": "^2.4.1"
       }
     },
     "@caliobase/typeorm-migrations": {

--- a/packages/caliobase-cdk/package.json
+++ b/packages/caliobase-cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caliobase/caliobase-cdk",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "dependencies": {
     "@ji-constructs/cdk-image-resize-behavior": "^0.5.9",
     "@ji-constructs/ecs-jwt-keypair": "^0.1.7",

--- a/packages/caliobase-nx/package.json
+++ b/packages/caliobase-nx/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@caliobase/caliobase-nx",
-  "version": "0.3.53",
+  "version": "0.3.54",
   "main": "src/index.js",
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
-    "@caliobase/caliobase-ui": "0.3.49",
-    "@caliobase/caliobase": "0.7.20",
+    "@caliobase/caliobase-ui": "0.3.50",
+    "@caliobase/caliobase": "0.7.21",
     "@nestjs/common": "10.3.3",
     "@nestjs/core": "10.3.3",
     "@nestjs/platform-express": "10.3.3",

--- a/packages/caliobase-ui/package.json
+++ b/packages/caliobase-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caliobase/caliobase-ui",
-  "version": "0.3.49",
+  "version": "0.3.50",
   "dependencies": {
     "react": "^18.2.0",
     "@floating-ui/react-dom-interactions": "^0.9.2",
@@ -17,7 +17,7 @@
     "@editorjs/header": "^2.6.2",
     "@editorjs/image": "^2.6.2",
     "@editorjs/list": "^1.7.0",
-    "use-async-effect-state": "0.2.48",
+    "use-async-effect-state": "0.2.49",
     "rxjs": "^7.0.0",
     "react-router-dom": "6.11.2",
     "circumspect": "^0.1.1",

--- a/packages/caliobase/package.json
+++ b/packages/caliobase/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@caliobase/caliobase",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.282.0",
     "@aws-sdk/s3-request-presigner": "^3.282.0",
-    "@caliobase/typeorm-migrations": "0.0.52",
+    "@caliobase/typeorm-migrations": "0.0.53",
     "@faire/mjml-react": "^3.3.0",
     "@nestjs/common": "^10.3.3",
     "@nestjs/config": "^3.2.0",

--- a/packages/typeorm-migrations/package.json
+++ b/packages/typeorm-migrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caliobase/typeorm-migrations",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "dependencies": {
     "@sqltools/formatter": "1.2.5",
     "circumspect": "^0.1.1",

--- a/packages/use-async-effect-state/package.json
+++ b/packages/use-async-effect-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-async-effect-state",
-  "version": "0.2.48",
+  "version": "0.2.49",
   "dependencies": {
     "react": "^18.2.0",
     "rxjs": "^7.0.0"


### PR DESCRIPTION
## Summary
- sync the successful `0.7.21` package release commit back to `main`
- bring package manifests and lockfile up to the versions already published to npm
- preserves the release commit generated by the GitHub Actions run; the original workflow could publish packages/tags but could not push `main` because branch protection requires PRs

## Validation
- release workflow published packages successfully before failing on protected `main` push
- verified npm latest versions:
  - `@caliobase/caliobase@0.7.21`
  - `@caliobase/caliobase-nx@0.3.54`
  - `@caliobase/caliobase-cdk@0.2.48`
  - `@caliobase/caliobase-ui@0.3.50`
  - `@caliobase/typeorm-migrations@0.0.53`
  - `use-async-effect-state@0.2.49`
- `git diff --check`
