### PR TITLE
ci: split release prepare and publish

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,10 +1,10 @@
-name: Release
+name: Release Prepare
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version bump/specifier to release'
+        description: 'Version bump/specifier to prepare'
         required: true
         default: patch
         type: choice
@@ -18,38 +18,44 @@ on:
         required: false
         type: string
       dry_run:
-        description: 'Run the release flow without publishing or pushing tags'
+        description: 'Run the release preparation without opening a PR'
         required: true
         default: true
         type: boolean
-
 concurrency:
   group: caliobase-release
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
-  release:
-    name: Release npm packages
+  prepare:
+    name: Prepare release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       CI: true
-      NPM_CONFIG_PROVENANCE: true
+      GH_TOKEN: ${{ github.token }}
 
     steps:
       - name: Require main branch
         if: github.ref != 'refs/heads/main'
         run: |
-          echo "Releases must be run from main. Current ref: $GITHUB_REF" >&2
+          echo "Releases must be prepared from main. Current ref: $GITHUB_REF" >&2
           exit 1
 
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Create release branch
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git switch -c "release/${{ inputs.version }}-${{ github.run_id }}"
 
       - name: Setup Docker Compose
         uses: docker/setup-compose-action@v1
@@ -60,11 +66,6 @@ jobs:
           node-version: '20'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Use npm with trusted publishing support
-        run: |
-          npm install -g npm@^11.5.1
-          npm --version
 
       - name: Configure git author
         run: |
@@ -90,13 +91,13 @@ jobs:
           timeout 120 bash -c 'until docker compose exec -T minio mc ready local > /dev/null 2>&1; do echo "Waiting for MinIO..."; sleep 5; done'
           echo "All services are ready!"
 
-      - name: Release
+      - name: Prepare release commit
         env:
           RELEASE_VERSION: ${{ inputs.version }}
           RELEASE_PREID: ${{ inputs.preid }}
           RELEASE_DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          args=("$RELEASE_VERSION")
+          args=(prepare "$RELEASE_VERSION")
           if [[ -n "$RELEASE_PREID" ]]; then
             args+=("--preid" "$RELEASE_PREID")
           fi
@@ -104,6 +105,40 @@ jobs:
             args+=("--dry-run")
           fi
           npm run release -- "${args[@]}"
+
+      - name: Push release branch
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git push --set-upstream origin HEAD
+
+      - name: Open release PR
+        if: ${{ !inputs.dry_run }}
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_PREID: ${{ inputs.preid }}
+        run: |
+          title="chore(release): ${RELEASE_VERSION} release"
+          if [[ -n "$RELEASE_PREID" ]]; then
+            title="chore(release): ${RELEASE_VERSION} ${RELEASE_PREID} release"
+          fi
+
+          cat > /tmp/release-pr-body.md <<'BODY'
+          ## Summary
+          - prepares the release version bump
+          - publishing is intentionally separate and runs only after this PR merges to `main`
+
+          ## Zero-trust release flow
+          - this PR does not publish to npm
+          - the publish job has no write permission to `main`
+          - npm publishing uses trusted publishing via GitHub Actions OIDC, not an npm token
+          - release tags are pushed by a separate post-publish job with no npm/OIDC permission
+          BODY
+
+          gh pr create \
+            --base main \
+            --head "$(git branch --show-current)" \
+            --title "$title" \
+            --body-file /tmp/release-pr-body.md
 
       - name: Cleanup test infrastructure
         if: always()

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,76 @@
+name: Release Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/*/package.json'
+
+concurrency:
+  group: caliobase-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish unpublished npm packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CI: true
+      NPM_CONFIG_PROVENANCE: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Use npm with trusted publishing support
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish missing versions
+        run: npm run release -- publish
+
+  tag:
+    name: Tag published package versions
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Push missing release tags
+        run: npm run release -- tag

--- a/README.md
+++ b/README.md
@@ -91,13 +91,16 @@ Visit [Nx Cloud](https://nx.app/) to learn more.
 
 ## Releases
 
-Caliobase packages are released from GitHub Actions instead of a developer machine.
+Caliobase packages are released with a PR-first GitHub Actions flow instead of publishing from a developer machine.
 
-1. Open **Actions → Release** in GitHub.
+1. Open **Actions → Release Prepare** in GitHub.
 2. Run the workflow from `main`.
 3. Choose the version bump (`patch`, `minor`, `major`, or `prerelease`).
-4. Leave `dry_run` enabled for a smoke test, or disable it to publish.
+4. Leave `dry_run` enabled for a smoke test, or disable it to open a release version-bump PR.
+5. Merge the release PR after the required checks pass.
 
-The release workflow runs tests/builds, uses Nx Release to update package versions and changelogs, publishes packages to npm, and pushes the release commit/tags back to GitHub. npm publishing uses trusted publishing via GitHub Actions OIDC, so each published package must trust this repository/workflow in npm and no `NPM_TOKEN` secret is required.
+After the release PR merges to `main`, **Release Publish** publishes any workspace package versions that do not already exist on npm. Publishing uses npm trusted publishing via GitHub Actions OIDC, so each published package must trust this repository/workflow in npm and no `NPM_TOKEN` secret is required. The publish job has read-only repository permissions plus `id-token: write`; it cannot write back to `main`.
 
-Local fallback remains available with `npm run release -- patch`; local publishes prompt for an npm OTP unless `NPM_OTP` is set.
+After publishing succeeds, a separate tag job with no npm/OIDC permission creates any missing release tags for the versions on disk. This keeps Nx's tag-based version resolution intact without giving one job both npm publish authority and repository write authority.
+
+Local release preparation remains available with `npm run release -- prepare patch`; local publishing can be tested with `npm run release -- publish --dry-run`; local tag backfill can be tested with `npm run release -- tag`.

--- a/tools/scripts/release.sh
+++ b/tools/scripts/release.sh
@@ -4,27 +4,30 @@ set -euo pipefail
 RELEASE_SPECIFIER="patch"
 PREID=""
 DRY_RUN="false"
+MODE="prepare"
 
 usage() {
   cat <<'USAGE'
-Usage: npm run release -- [patch|minor|major|prerelease|prepatch|preminor|premajor|<version>] [--preid <id>|--preid=<id>] [--dry-run]
+Usage: npm run release -- [prepare|publish|tag] [patch|minor|major|prerelease|prepatch|preminor|premajor|<version>] [--preid <id>|--preid=<id>] [--dry-run]
 
-Runs the caliobase Nx release flow:
-  1. fetch tags
-  2. test
-  3. build
-  4. version/changelog/tag packages
-  5. rebuild
-  6. publish to npm
-  7. push commits/tags
+Modes:
+  prepare  Run tests/builds and create the release version-bump commit for a PR.
+           This does not publish to npm and does not push to main.
+  publish  Build and publish package versions that do not already exist on npm.
+           CI publishing uses npm trusted publishing via GitHub Actions OIDC.
+  tag      Create any missing release git tags for the versions on disk.
+           This does not publish to npm.
 
-Local releases prompt for npm OTP unless NPM_OTP or NPM_TOKEN is set.
-CI releases use npm trusted publishing via GitHub Actions OIDC.
+Default mode is prepare.
 USAGE
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    prepare|publish|tag)
+      MODE="$1"
+      shift
+      ;;
     --dry-run)
       DRY_RUN="true"
       shift
@@ -62,8 +65,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-NX_VERSION_ARGS=("$RELEASE_SPECIFIER")
-NX_PUBLISH_ARGS=()
+NX_VERSION_ARGS=("$RELEASE_SPECIFIER" "--git-tag=false" "--git-push=false")
+NX_PUBLISH_ARGS=("--outputStyle=static")
 
 if [[ -n "$PREID" ]]; then
   NX_VERSION_ARGS+=("--preid" "$PREID")
@@ -74,41 +77,96 @@ if [[ "$DRY_RUN" == "true" ]]; then
   NX_PUBLISH_ARGS+=("--dry-run")
 fi
 
-# Fetch tags and run tests/build
-git fetch --all --tags
-npm run test
-npm run build
+release_project_specs() {
+  node <<'NODE'
+const { readdirSync, readFileSync, existsSync } = require('node:fs');
+const { join } = require('node:path');
 
-# Version bump / changelog / tags
-npx nx release version "${NX_VERSION_ARGS[@]}"
+for (const dirent of readdirSync('packages', { withFileTypes: true })) {
+  if (!dirent.isDirectory()) continue;
+  const packageJsonPath = join('packages', dirent.name, 'package.json');
+  const projectJsonPath = join('packages', dirent.name, 'project.json');
+  if (!existsSync(packageJsonPath) || !existsSync(projectJsonPath)) continue;
 
-# Rebuild with new versions
-npm run build
+  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  const project = JSON.parse(readFileSync(projectJsonPath, 'utf8'));
+  if (!pkg.name || !pkg.version || pkg.private) continue;
 
-if [[ "$DRY_RUN" == "true" ]]; then
-  echo "Dry run complete; skipping npm publish and git push."
-  exit 0
-fi
+  console.log(`${project.name || dirent.name}\t${pkg.name}\t${pkg.version}`);
+}
+NODE
+}
 
-if [[ "${CI:-}" != "true" && -z "${NPM_TOKEN:-}" ]]; then
-  if [[ -z "${NPM_OTP:-}" ]]; then
-    echo ""
-    echo "Ready to publish to npm."
-    read -r -p "Enter your npm OTP code: " NPM_OTP
+publish_missing_versions() {
+  local missing_projects=()
+  local project package_name version spec view_output
+
+  while IFS=$'\t' read -r project package_name version; do
+    spec="${package_name}@${version}"
+    if view_output=$(npm view "$spec" version --json 2>&1); then
+      echo "Already published: $spec" >&2
+      continue
+    fi
+
+    if [[ "$view_output" != *"E404"* ]]; then
+      echo "$view_output" >&2
+      exit 1
+    fi
+
+    echo "Will publish: $spec" >&2
+    missing_projects+=("$project")
+  done < <(release_project_specs)
+
+  if [[ "${#missing_projects[@]}" -eq 0 ]]; then
+    echo "All workspace package versions already exist on npm; nothing to publish."
+    return 0
   fi
 
-  if [[ -z "${NPM_OTP:-}" ]]; then
-    echo "Error: OTP is required for local releases unless NPM_TOKEN is set." >&2
+  local projects_csv
+  projects_csv=$(IFS=,; echo "${missing_projects[*]}")
+  npx nx release publish --projects="$projects_csv" "${NX_PUBLISH_ARGS[@]}"
+}
+
+tag_published_versions() {
+  local tags=()
+  local project package_name version tag
+
+  while IFS=$'\t' read -r project package_name version; do
+    tag="${project}-${version}"
+    if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+      echo "Tag already exists: $tag"
+      continue
+    fi
+
+    echo "Creating tag: $tag for $package_name@$version"
+    git tag -a "$tag" -m "$tag"
+    tags+=("refs/tags/$tag")
+  done < <(release_project_specs)
+
+  if [[ "${#tags[@]}" -eq 0 ]]; then
+    echo "All release tags already exist; nothing to push."
+    return 0
+  fi
+
+  git push origin "${tags[@]}"
+}
+
+case "$MODE" in
+  prepare)
+    git fetch --all --tags
+    npm run test
+    npm run build
+    npx nx release version "${NX_VERSION_ARGS[@]}"
+    ;;
+  publish)
+    npm run build
+    publish_missing_versions
+    ;;
+  tag)
+    tag_published_versions
+    ;;
+  *)
+    echo "Error: unknown release mode '$MODE'" >&2
     exit 1
-  fi
-fi
-
-if [[ -n "${NPM_OTP:-}" ]]; then
-  NX_PUBLISH_ARGS+=("--otp=$NPM_OTP")
-fi
-
-# Publish to npm
-npx nx release publish "${NX_PUBLISH_ARGS[@]}"
-
-# Push release commits/tags
-git push --follow-tags
+    ;;
+esac


### PR DESCRIPTION
## Summary
- split release automation into separate **Release Prepare** and **Release Publish** workflows
- prepare workflow opens a version-bump PR instead of publishing/pushing directly to `main`
- publish workflow runs on `main` package version changes and only publishes package versions missing from npm
- tag job runs after publish and backfills Nx release tags without npm/OIDC permission

## Validation
- `bash -n tools/scripts/release.sh`
- parsed `.github/workflows/release-prepare.yml` and `.github/workflows/release-publish.yml` with PyYAML
- `git diff --check`
- `ASDF_NODEJS_VERSION=20.20.2 npm ci --ignore-scripts`
- `ASDF_NODEJS_VERSION=20.20.2 npm run release -- publish --dry-run`
- `ASDF_NODEJS_VERSION=20.20.2 npm run release -- tag`
