### PR TITLE
fix(caliobase): run migrations before codegen exit

### DIFF
--- a/packages/caliobase-nx/src/generators/client/generator.ts
+++ b/packages/caliobase-nx/src/generators/client/generator.ts
@@ -102,7 +102,7 @@ export default async function (tree: Tree, options: ClientGeneratorSchema) {
             },
           ],
           options: {
-            command: `node ./dist/${apiProjectConfig.root}/main.js --write-swagger-and-exit=./${normalizedOptions.projectRoot}/assets/openapi.json`,
+            command: `node ./dist/${apiProjectConfig.root}/main.js --write-swagger=./${normalizedOptions.projectRoot}/assets/openapi.json --exit-after-codegen`,
           },
         },
       };

--- a/packages/caliobase/src/caliobase.module.ts
+++ b/packages/caliobase/src/caliobase.module.ts
@@ -67,29 +67,37 @@ export class CaliobaseModule {
 
     SwaggerModule.setup('swagger', app, document);
 
-    const { writeSwagger, writeSwaggerAndExit } = new Command()
-      .option(`--write-swagger [path]`)
-      .option(`--write-swagger-and-exit [path]`)
-      .parse(process.argv)
-      .opts();
+    const { writeSwagger, writeSwaggerAndExit, exitAfterCodegen } =
+      new Command()
+        .option(`--write-swagger [path]`)
+        .option(`--write-swagger-and-exit [path]`)
+        .option(`--exit-after-codegen`)
+        .parse(process.argv)
+        .opts();
 
-    if (writeSwagger || writeSwaggerAndExit) {
-      const swaggerPath = writeSwagger || writeSwaggerAndExit;
-      await mkdir(join(swaggerPath, '..'), {
+    if (writeSwaggerAndExit) {
+      throw new Error(
+        `The --write-swagger-and-exit flag has been removed. Migrate to --write-swagger=<path> --exit-after-codegen so migrations are generated before exit.`
+      );
+    }
+
+    if (writeSwagger) {
+      await mkdir(join(writeSwagger, '..'), {
         recursive: true,
       });
       await writeFileIfDifferent(
-        swaggerPath,
+        writeSwagger,
         JSON.stringify(document, null, 2)
       );
-      if (writeSwaggerAndExit) {
-        await app.close();
-        process.exit(0);
-      }
     }
 
     if (options.migration != null) {
       await runMigrations(app.get(DataSource), options.migration);
+    }
+
+    if (exitAfterCodegen) {
+      await app.close();
+      process.exit(0);
     }
 
     const server = app.getHttpServer();


### PR DESCRIPTION
## Summary
- replace `--write-swagger-and-exit` with separate `--write-swagger=<path>` and `--exit-after-codegen` flags
- make the removed flag fail with an explicit migration error
- move the exit path after migration generation so codegen runs Swagger + migrations before shutdown
- update the caliobase-nx client generator to emit the new flag pair

## Validation
- `ASDF_NODEJS_VERSION=20.20.2 npx nx test caliobase-nx --testFile=packages/caliobase-nx/src/generators/client/generator.spec.ts`
- `ASDF_NODEJS_VERSION=20.20.2 npx nx build typeorm-migrations --skip-nx-cache`
- `ASDF_NODEJS_VERSION=20.20.2 npx nx build caliobase --skip-nx-cache`
- `ASDF_NODEJS_VERSION=20.20.2 npx nx build caliobase-nx --skip-nx-cache`
