### PR TITLE
test(caliobase): avoid external URL in object storage test

### DIFF
--- a/packages/caliobase/src/object-storage/object-storage.spec.ts
+++ b/packages/caliobase/src/object-storage/object-storage.spec.ts
@@ -44,7 +44,7 @@ describe('object storage', () => {
     const objectStorageService = module.get(ObjectStorageService);
 
     const request: ObjectCreateFromUrlRequest = {
-      source: new URL('https://google.com'),
+      source: new URL('data:text/plain,object-storage-test'),
       fileName: randomFileName,
       organization,
       uploadedBy: owner.user,
@@ -54,8 +54,8 @@ describe('object storage', () => {
 
     expect(
       await objectStorage.fileExists(
-        objectStorageService.getKeyForFile(request)
-      )
+        objectStorageService.getKeyForFile(request),
+      ),
     ).toEqual(true);
   });
 });


### PR DESCRIPTION
## Summary
- stop the object-storage upload-from-URL test from fetching `https://google.com`
- use a deterministic `data:` URL instead so CI is not exposed to external rate limiting

## Validation
- `ASDF_NODEJS_VERSION=20.20.2 npx nx test caliobase --testFile=packages/caliobase/src/object-storage/object-storage.spec.ts`
