### PR TITLE
fix(release): resolve versions from package manifests

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -108,7 +108,9 @@
     "projects": ["packages/*", "!packages/*-e2e", "!packages/test-infra"],
     "projectsRelationship": "independent",
     "version": {
-      "conventionalCommits": true,
+      "// currentVersionResolver": "Use package manifests as the version source. Release tags can point at side-branch publish commits, which are not always reachable from main.",
+      "currentVersionResolver": "disk",
+      "specifierSource": "prompt",
       "git": {
         "commit": true,
         "commitArgs": "--no-verify",

--- a/tools/scripts/release.sh
+++ b/tools/scripts/release.sh
@@ -127,6 +127,33 @@ publish_missing_versions() {
   npx nx release publish --projects="$projects_csv" "${NX_PUBLISH_ARGS[@]}"
 }
 
+run_prepare_release() {
+  local before_head after_head
+  before_head=$(git rev-parse HEAD)
+
+  git fetch --all --tags
+  npm run test
+  npm run build
+  npx nx release version "${NX_VERSION_ARGS[@]}"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    return 0
+  fi
+
+  after_head=$(git rev-parse HEAD)
+  if [[ "$after_head" == "$before_head" ]]; then
+    echo "Error: release versioning did not create a release commit." >&2
+    exit 1
+  fi
+
+  if ! git diff --name-only "$before_head..$after_head" -- 'packages/*/package.json' | grep -q .; then
+    echo "Error: release versioning did not change any package manifests; refusing to open an empty release PR." >&2
+    echo "Changed files were:" >&2
+    git diff --name-only "$before_head..$after_head" >&2
+    exit 1
+  fi
+}
+
 tag_published_versions() {
   local tags=()
   local project package_name version tag
@@ -153,10 +180,7 @@ tag_published_versions() {
 
 case "$MODE" in
   prepare)
-    git fetch --all --tags
-    npm run test
-    npm run build
-    npx nx release version "${NX_VERSION_ARGS[@]}"
+    run_prepare_release
     ;;
   publish)
     npm run build


### PR DESCRIPTION
## Summary
- make release preparation resolve current package versions from package manifests instead of reachable git tags
- add a guard so release preparation refuses to open a PR unless package manifests changed

## Why
The existing `0.7.21` release tags point at a side-branch publish commit that is not reachable from `main`. Nx therefore resolved `main` as being at `0.7.20`, tried to bump to `0.7.21`, and produced a release PR with only lockfile churn because the manifests already said `0.7.21`.

## Validation
- `bash -n tools/scripts/release.sh`
- `ASDF_NODEJS_VERSION=20.20.2 npx nx release version patch --dry-run --git-tag=false --git-push=false`
  - confirmed versions resolve from manifests and dry-run would bump `@caliobase/caliobase` `0.7.21` → `0.7.22` and `@caliobase/caliobase-nx` `0.3.54` → `0.3.55`
