### PR TITLE
fix(release): enable auto-merge for release PRs

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -134,11 +134,13 @@ jobs:
           - release tags are pushed by a separate post-publish job with no npm/OIDC permission
           BODY
 
-          gh pr create \
+          pr_url=$(gh pr create \
             --base main \
             --head "$(git branch --show-current)" \
             --title "$title" \
-            --body-file /tmp/release-pr-body.md
+            --body-file /tmp/release-pr-body.md)
+
+          gh pr merge "$pr_url" --auto --merge
 
       - name: Cleanup test infrastructure
         if: always()


### PR DESCRIPTION
## Summary
- capture the release PR URL from `gh pr create`
- immediately request GitHub auto-merge with merge commits for non-dry-run prepare-release PRs

## Validation
- `python` assertion that the workflow contains the auto-merge command
