### PR TITLE
ci(release): prepare releases after main updates

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,6 +1,15 @@
 name: Release Prepare
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/**'
+      - 'tools/scripts/release.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'nx.json'
   workflow_dispatch:
     inputs:
       version:
@@ -22,6 +31,7 @@ on:
         required: true
         default: true
         type: boolean
+
 concurrency:
   group: caliobase-release
   cancel-in-progress: false
@@ -33,12 +43,20 @@ jobs:
   prepare:
     name: Prepare release PR
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'push' ||
+      !contains(github.event.head_commit.message, 'chore(release):')
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     env:
       CI: true
       GH_TOKEN: ${{ github.token }}
+      RELEASE_VERSION: ${{ inputs.version || 'patch' }}
+      RELEASE_PREID: ${{ inputs.preid || '' }}
+      RELEASE_DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      RELEASE_SKIP_EMPTY: ${{ github.event_name == 'push' && 'true' || 'false' }}
 
     steps:
       - name: Require main branch
@@ -53,9 +71,11 @@ jobs:
           fetch-depth: 0
 
       - name: Create release branch
-        if: ${{ !inputs.dry_run }}
+        if: env.RELEASE_DRY_RUN != 'true'
         run: |
-          git switch -c "release/${{ inputs.version }}-${{ github.run_id }}"
+          branch="release/${RELEASE_VERSION}-${GITHUB_RUN_ID}"
+          git switch -c "$branch"
+          echo "RELEASE_BRANCH=$branch" >> "$GITHUB_ENV"
 
       - name: Setup Docker Compose
         uses: docker/setup-compose-action@v1
@@ -92,10 +112,7 @@ jobs:
           echo "All services are ready!"
 
       - name: Prepare release commit
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-          RELEASE_PREID: ${{ inputs.preid }}
-          RELEASE_DRY_RUN: ${{ inputs.dry_run }}
+        id: prepare
         run: |
           args=(prepare "$RELEASE_VERSION")
           if [[ -n "$RELEASE_PREID" ]]; then
@@ -104,18 +121,29 @@ jobs:
           if [[ "$RELEASE_DRY_RUN" == "true" ]]; then
             args+=("--dry-run")
           fi
+          if [[ "$RELEASE_SKIP_EMPTY" == "true" ]]; then
+            args+=("--skip-empty")
+          fi
+
+          before_head=$(git rev-parse HEAD)
           npm run release -- "${args[@]}"
+          after_head=$(git rev-parse HEAD)
+
+          if [[ "$before_head" == "$after_head" ]]; then
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Push release branch
-        if: ${{ !inputs.dry_run }}
+        if: env.RELEASE_DRY_RUN != 'true' && steps.prepare.outputs.created == 'true'
         run: |
           git push --set-upstream origin HEAD
 
       - name: Open release PR
-        if: ${{ !inputs.dry_run }}
+        if: env.RELEASE_DRY_RUN != 'true' && steps.prepare.outputs.created == 'true'
         env:
-          RELEASE_VERSION: ${{ inputs.version }}
-          RELEASE_PREID: ${{ inputs.preid }}
+          RELEASE_BRANCH: ${{ env.RELEASE_BRANCH }}
         run: |
           title="chore(release): ${RELEASE_VERSION} release"
           if [[ -n "$RELEASE_PREID" ]]; then
@@ -124,7 +152,7 @@ jobs:
 
           cat > /tmp/release-pr-body.md <<'BODY'
           ## Summary
-          - prepares the release version bump
+          - automatically prepares the release version bump after changes land on `main`
           - publishing is intentionally separate and runs only after this PR merges to `main`
 
           ## Zero-trust release flow
@@ -136,11 +164,16 @@ jobs:
 
           pr_url=$(gh pr create \
             --base main \
-            --head "$(git branch --show-current)" \
+            --head "$RELEASE_BRANCH" \
             --title "$title" \
             --body-file /tmp/release-pr-body.md)
 
           gh pr merge "$pr_url" --auto --merge
+
+          # PRs created by GITHUB_TOKEN do not naturally trigger pull_request workflows.
+          # Dispatch Test explicitly against the release branch so the required `test`
+          # check is attached to the PR head SHA and auto-merge can proceed.
+          gh workflow run test.yml --ref "$RELEASE_BRANCH"
 
       - name: Cleanup test infrastructure
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -91,15 +91,15 @@ Visit [Nx Cloud](https://nx.app/) to learn more.
 
 ## Releases
 
-Caliobase packages are released with a PR-first GitHub Actions flow instead of publishing from a developer machine.
+Caliobase packages are released with an automatic PR-first GitHub Actions flow instead of publishing from a developer machine.
 
-1. Open **Actions → Release Prepare** in GitHub.
-2. Run the workflow from `main`.
-3. Choose the version bump (`patch`, `minor`, `major`, or `prerelease`).
-4. Leave `dry_run` enabled for a smoke test, or disable it to open a release version-bump PR.
-5. Merge the release PR after the required checks pass.
+1. Merge package changes to `main`.
+2. **Release Prepare** runs automatically, creates a release version-bump PR, enables auto-merge, and explicitly dispatches the required **Test** workflow for that release branch.
+3. After the release PR merges to `main`, **Release Publish** publishes any workspace package versions that do not already exist on npm.
 
-After the release PR merges to `main`, **Release Publish** publishes any workspace package versions that do not already exist on npm. Publishing uses npm trusted publishing via GitHub Actions OIDC, so each published package must trust this repository/workflow in npm and no `NPM_TOKEN` secret is required. The publish job has read-only repository permissions plus `id-token: write`; it cannot write back to `main`.
+Manual **Release Prepare** dispatch is still available as an emergency fallback or dry-run smoke test, but the normal release path starts from pushes to `main`.
+
+Publishing uses npm trusted publishing via GitHub Actions OIDC, so each published package must trust this repository/workflow in npm and no `NPM_TOKEN` secret is required. The publish job has read-only repository permissions plus `id-token: write`; it cannot write back to `main`.
 
 After publishing succeeds, a separate tag job with no npm/OIDC permission creates any missing release tags for the versions on disk. This keeps Nx's tag-based version resolution intact without giving one job both npm publish authority and repository write authority.
 

--- a/tools/scripts/release.ts
+++ b/tools/scripts/release.ts
@@ -22,6 +22,7 @@ interface ReleaseOptions {
   specifier: string;
   preid: string;
   dryRun: boolean;
+  skipEmpty: boolean;
 }
 
 interface ReleaseProjectSpec {
@@ -32,7 +33,7 @@ interface ReleaseProjectSpec {
 }
 
 function usage(): string {
-  return `Usage: npm run release -- [prepare|publish|tag] [patch|minor|major|prerelease|prepatch|preminor|premajor|<version>] [--preid <id>|--preid=<id>] [--dry-run]
+  return `Usage: npm run release -- [prepare|publish|tag] [patch|minor|major|prerelease|prepatch|preminor|premajor|<version>] [--preid <id>|--preid=<id>] [--dry-run] [--skip-empty]
 
 Modes:
   prepare  Run tests/builds and create the release version-bump commit for a PR.
@@ -51,6 +52,7 @@ function parseArgs(argv: string[]): ReleaseOptions {
     specifier: 'patch',
     preid: '',
     dryRun: false,
+    skipEmpty: false,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -63,6 +65,11 @@ function parseArgs(argv: string[]): ReleaseOptions {
 
     if (arg === '--dry-run') {
       options.dryRun = true;
+      continue;
+    }
+
+    if (arg === '--skip-empty') {
+      options.skipEmpty = true;
       continue;
     }
 
@@ -241,9 +248,14 @@ function prepareRelease(options: ReleaseOptions): void {
 
   const releaseProjects = changedReleaseProjects();
   if (releaseProjects.length === 0) {
-    throw new Error(
-      'Error: no publishable package projects changed since their current release tags; refusing to create an empty release PR.'
-    );
+    const message =
+      'No publishable package projects changed since their current release tags; no release PR needed.';
+    if (options.skipEmpty) {
+      console.log(message);
+      return;
+    }
+
+    throw new Error(`Error: ${message}`);
   }
 
   run('npx', [


### PR DESCRIPTION
## Summary
- run Release Prepare automatically on pushes to `main` that touch package/release inputs
- keep manual dispatch as an emergency/dry-run fallback, but make it non-required
- explicitly dispatch the required Test workflow for GITHUB_TOKEN-created release PR branches so auto-merge has a real `test` check
- skip empty automatic release prepares instead of failing when release tags are already current

## Validation
- parsed modified workflow YAML with PyYAML
- ran `npm run release -- --help`
- ran `npx tsc --noEmit --pretty false tools/scripts/release.ts`
