### PR TITLE
fix(release): prevent duplicate release PRs

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -70,17 +70,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create release branch
+      - name: Check for existing release PR
+        id: existing_release
         if: env.RELEASE_DRY_RUN != 'true'
+        run: |
+          existing_prs=$(gh pr list \
+            --base main \
+            --state open \
+            --json number,title,headRefName,url \
+            --jq '[.[] | select(.headRefName | startswith("release/"))]')
+          count=$(jq 'length' <<<"$existing_prs")
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [[ "$count" != "0" ]]; then
+            echo "Found existing release PR(s); skipping duplicate release generation."
+            jq -r '.[] | "- #\(.number) \(.title): \(.url)"' <<<"$existing_prs"
+          fi
+
+      - name: Create release branch
+        if: env.RELEASE_DRY_RUN != 'true' && steps.existing_release.outputs.count == '0'
         run: |
           branch="release/${RELEASE_VERSION}-${GITHUB_RUN_ID}"
           git switch -c "$branch"
           echo "RELEASE_BRANCH=$branch" >> "$GITHUB_ENV"
 
       - name: Setup Docker Compose
+        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         uses: docker/setup-compose-action@v1
 
       - name: Setup Node.js
+        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -88,19 +106,23 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Configure git author
+        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install dependencies
+        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         run: npm ci
 
       - name: Start test infrastructure
+        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         run: |
           cd packages/test-infra
           docker compose up -d
 
       - name: Wait for services to be ready
+        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         run: |
           cd packages/test-infra
           echo "Waiting for services to be healthy..."
@@ -113,6 +135,7 @@ jobs:
 
       - name: Prepare release commit
         id: prepare
+        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         run: |
           args=(prepare "$RELEASE_VERSION")
           if [[ -n "$RELEASE_PREID" ]]; then
@@ -136,12 +159,12 @@ jobs:
           fi
 
       - name: Push release branch
-        if: env.RELEASE_DRY_RUN != 'true' && steps.prepare.outputs.created == 'true'
+        if: env.RELEASE_DRY_RUN != 'true' && steps.existing_release.outputs.count == '0' && steps.prepare.outputs.created == 'true'
         run: |
           git push --set-upstream origin HEAD
 
       - name: Open release PR
-        if: env.RELEASE_DRY_RUN != 'true' && steps.prepare.outputs.created == 'true'
+        if: env.RELEASE_DRY_RUN != 'true' && steps.existing_release.outputs.count == '0' && steps.prepare.outputs.created == 'true'
         env:
           RELEASE_BRANCH: ${{ env.RELEASE_BRANCH }}
         run: |
@@ -176,7 +199,7 @@ jobs:
           gh workflow run test.yml --ref "$RELEASE_BRANCH"
 
       - name: Cleanup test infrastructure
-        if: always()
+        if: always() && (env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0')
         run: |
           cd packages/test-infra
           docker compose down -v

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -70,8 +70,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for existing release PR
-        id: existing_release
+      - name: Report existing release PRs
         if: env.RELEASE_DRY_RUN != 'true'
         run: |
           existing_prs=$(gh pr list \
@@ -80,25 +79,22 @@ jobs:
             --json number,title,headRefName,url \
             --jq '[.[] | select(.headRefName | startswith("release/"))]')
           count=$(jq 'length' <<<"$existing_prs")
-          echo "count=$count" >> "$GITHUB_OUTPUT"
           if [[ "$count" != "0" ]]; then
-            echo "Found existing release PR(s); skipping duplicate release generation."
+            echo "Existing release PR(s) will be replaced after the new release PR is created."
             jq -r '.[] | "- #\(.number) \(.title): \(.url)"' <<<"$existing_prs"
           fi
 
       - name: Create release branch
-        if: env.RELEASE_DRY_RUN != 'true' && steps.existing_release.outputs.count == '0'
+        if: env.RELEASE_DRY_RUN != 'true'
         run: |
           branch="release/${RELEASE_VERSION}-${GITHUB_RUN_ID}"
           git switch -c "$branch"
           echo "RELEASE_BRANCH=$branch" >> "$GITHUB_ENV"
 
       - name: Setup Docker Compose
-        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         uses: docker/setup-compose-action@v1
 
       - name: Setup Node.js
-        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -106,23 +102,19 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Configure git author
-        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install dependencies
-        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         run: npm ci
 
       - name: Start test infrastructure
-        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         run: |
           cd packages/test-infra
           docker compose up -d
 
       - name: Wait for services to be ready
-        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         run: |
           cd packages/test-infra
           echo "Waiting for services to be healthy..."
@@ -135,7 +127,6 @@ jobs:
 
       - name: Prepare release commit
         id: prepare
-        if: env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0'
         run: |
           args=(prepare "$RELEASE_VERSION")
           if [[ -n "$RELEASE_PREID" ]]; then
@@ -159,12 +150,12 @@ jobs:
           fi
 
       - name: Push release branch
-        if: env.RELEASE_DRY_RUN != 'true' && steps.existing_release.outputs.count == '0' && steps.prepare.outputs.created == 'true'
+        if: env.RELEASE_DRY_RUN != 'true' && steps.prepare.outputs.created == 'true'
         run: |
           git push --set-upstream origin HEAD
 
       - name: Open release PR
-        if: env.RELEASE_DRY_RUN != 'true' && steps.existing_release.outputs.count == '0' && steps.prepare.outputs.created == 'true'
+        if: env.RELEASE_DRY_RUN != 'true' && steps.prepare.outputs.created == 'true'
         env:
           RELEASE_BRANCH: ${{ env.RELEASE_BRANCH }}
         run: |
@@ -191,6 +182,18 @@ jobs:
             --title "$title" \
             --body-file /tmp/release-pr-body.md)
 
+          existing_prs=$(gh pr list \
+            --base main \
+            --state open \
+            --json number,title,headRefName,url)
+          jq -r --arg branch "$RELEASE_BRANCH" \
+            '.[] | select((.headRefName | startswith("release/")) and .headRefName != $branch) | .number' \
+            <<<"$existing_prs" | while read -r pr_number; do
+              gh pr close "$pr_number" \
+                --comment "Closing this release PR because $pr_url replaces it." \
+                --delete-branch
+            done
+
           gh pr merge "$pr_url" --auto --merge
 
           # PRs created by GITHUB_TOKEN do not naturally trigger pull_request workflows.
@@ -199,7 +202,7 @@ jobs:
           gh workflow run test.yml --ref "$RELEASE_BRANCH"
 
       - name: Cleanup test infrastructure
-        if: always() && (env.RELEASE_DRY_RUN == 'true' || steps.existing_release.outputs.count == '0')
+        if: always()
         run: |
           cd packages/test-infra
           docker compose down -v

--- a/tools/scripts/release.ts
+++ b/tools/scripts/release.ts
@@ -239,6 +239,30 @@ function nxPublishArgs(options: ReleaseOptions): string[] {
   return args;
 }
 
+function syncPackageLockIntoReleaseCommit(): void {
+  if (!existsSync('package-lock.json')) {
+    return;
+  }
+
+  run('npm', ['install', '--package-lock-only', '--ignore-scripts']);
+
+  const lockDiff = commandResult('git', ['diff', '--quiet', '--', 'package-lock.json']);
+  if (lockDiff.status === 0) {
+    return;
+  }
+
+  run('git', ['add', 'package-lock.json']);
+  run('git', ['commit', '--amend', '--no-edit']);
+}
+
+function validatePackageLock(): void {
+  if (!existsSync('package-lock.json')) {
+    return;
+  }
+
+  run('npm', ['ci', '--ignore-scripts', '--dry-run']);
+}
+
 function prepareRelease(options: ReleaseOptions): void {
   const beforeHead = output('git', ['rev-parse', 'HEAD']);
 
@@ -269,6 +293,9 @@ function prepareRelease(options: ReleaseOptions): void {
   if (options.dryRun) {
     return;
   }
+
+  syncPackageLockIntoReleaseCommit();
+  validatePackageLock();
 
   const afterHead = output('git', ['rev-parse', 'HEAD']);
   if (afterHead === beforeHead) {


### PR DESCRIPTION
## Summary
- skip automatic release generation when an open `release/*` PR already exists
- sync `package-lock.json` back into the Nx release commit after versioning
- validate the generated lockfile with `npm ci --ignore-scripts --dry-run` before pushing/opening the release PR

## Validation
- `ASDF_NODEJS_VERSION=20.20.2 npx tsx tools/scripts/release.ts --help`
- `ASDF_NODEJS_VERSION=20.20.2 npm ci --ignore-scripts --dry-run`
- parsed `.github/workflows/release-prepare.yml` with PyYAML
