### PR TITLE
chore(release): patch release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37121,7 +37121,7 @@
     },
     "packages/caliobase": {
       "name": "@caliobase/caliobase",
-      "version": "0.7.21",
+      "version": "0.7.22",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.282.0",
         "@aws-sdk/s3-request-presigner": "^3.282.0",
@@ -37168,9 +37168,9 @@
     },
     "packages/caliobase-nx": {
       "name": "@caliobase/caliobase-nx",
-      "version": "0.3.54",
+      "version": "0.3.55",
       "dependencies": {
-        "@caliobase/caliobase": "0.7.21",
+        "@caliobase/caliobase": "0.7.22",
         "@caliobase/caliobase-ui": "0.3.50",
         "@nestjs/common": "10.3.3",
         "@nestjs/core": "10.3.3",
@@ -39881,7 +39881,7 @@
     "@caliobase/caliobase-nx": {
       "version": "file:packages/caliobase-nx",
       "requires": {
-        "@caliobase/caliobase": "0.7.21",
+        "@caliobase/caliobase": "0.7.22",
         "@caliobase/caliobase-ui": "0.3.50",
         "@nestjs/common": "10.3.3",
         "@nestjs/core": "10.3.3",

--- a/packages/caliobase-nx/package.json
+++ b/packages/caliobase-nx/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@caliobase/caliobase-nx",
-  "version": "0.3.54",
+  "version": "0.3.55",
   "main": "src/index.js",
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
     "@caliobase/caliobase-ui": "0.3.50",
-    "@caliobase/caliobase": "0.7.21",
+    "@caliobase/caliobase": "0.7.22",
     "@nestjs/common": "10.3.3",
     "@nestjs/core": "10.3.3",
     "@nestjs/platform-express": "10.3.3",

--- a/packages/caliobase/package.json
+++ b/packages/caliobase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caliobase/caliobase",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.282.0",
     "@aws-sdk/s3-request-presigner": "^3.282.0",


### PR DESCRIPTION
## Summary
- prepares the patch release version bump
- `@caliobase/caliobase`: `0.7.21` → `0.7.22`
- `@caliobase/caliobase-nx`: `0.3.54` → `0.3.55`

## Zero-trust release flow
- this PR does not publish to npm
- publishing runs only after this PR merges to `main`
- npm publishing uses trusted publishing via GitHub Actions OIDC, not an npm token
- release tags are pushed by a separate post-publish job with no npm/OIDC permission

## Validation
- `ASDF_NODEJS_VERSION=20.20.2 npm ci`
- `ASDF_NODEJS_VERSION=20.20.2 npx nx release version patch --git-tag=false --git-push=false --projects=caliobase,caliobase-nx`
- `ASDF_NODEJS_VERSION=20.20.2 npm install --package-lock-only --ignore-scripts`
- `ASDF_NODEJS_VERSION=20.20.2 npm ci --ignore-scripts --dry-run`
